### PR TITLE
Fix security vulnerabilities in dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -234,18 +234,18 @@ test = ["coverage", "hypothesis", "pytest", "pytz"]
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "numpy"
@@ -629,14 +629,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary

Resolves the 3 open Dependabot security alerts reported in the repository's Security tab by updating the vulnerable dependencies in `poetry.lock`.

| Alert | Package | Severity | Issue |
|-------|---------|----------|-------|
| #9 | urllib3 | High | Decompression-bomb safeguards bypassed in parts of the streaming API |
| #10 | urllib3 | High | Sensitive headers forwarded across origins in proxied low-level redirects |
| #11 | idna | Medium | Specially crafted inputs to `idna.encode()` can bypass the CVE-2024-3651 fix |

## Changes

- **urllib3** `2.6.3` → `2.7.0` (patched version ≥ 2.7.0) — fixes #9 and #10
- **idna** `3.10` → `3.18` (patched version ≥ 3.15) — fixes #11

Only `poetry.lock` is modified; the existing `pyproject.toml` constraints already permit these versions, so no constraint changes were needed. `poetry check --lock` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)