### PR TITLE
setuptools 依存を削除してセキュリティ脆弱性を解消

### DIFF
--- a/pkg_resources_compat.py
+++ b/pkg_resources_compat.py
@@ -1,0 +1,23 @@
+"""setuptools>=82 で削除された pkg_resources の最小互換シム。
+
+twitter-text-parser 3.0.0 が twitter_text/regexp/emoji.py で
+pkg_resources.resource_string() を使って同梱の emoji-test.txt を
+読み込んでいるが、pkg_resources は setuptools 82.0.0 で削除された。
+上流に修正版が無いため、こちら側で後継の importlib.resources に
+委譲する代替モジュールを sys.modules に登録して互換性を保つ。
+
+このモジュールは twitter_text より前に import すること。
+
+twitter-text-parser が更新されるか別ライブラリへ移行した時点で削除可。
+参照: https://github.com/magicien/Nij.iCal/security/dependabot/12
+"""
+import sys
+import types
+from importlib.resources import files
+
+try:
+    import pkg_resources  # noqa: F401
+except ModuleNotFoundError:
+    _m = types.ModuleType("pkg_resources")
+    _m.resource_string = lambda package, resource: (files(package) / resource).read_bytes()
+    sys.modules["pkg_resources"] = _m

--- a/poetry.lock
+++ b/poetry.lock
@@ -547,27 +547,6 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "setuptools"
-version = "80.9.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
-    {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.8.0) ; sys_platform != \"cygwin\""]
-core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -648,4 +627,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "0c1ea10e7fa1bd4b8254d3f4cdb56018fc2ac4f362e3ead26d6efe702de473ef"
+content-hash = "29467269670bc0f4e894de11999f616031ab459ae376fa6e11cb0aa619c6f4fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "playwright (>=1.48.0,<2.0.0)",
     "requests-oauthlib (>=2.0.0,<3.0.0)",
     "twitter-text-parser (>=3.0.0,<4.0.0)",
-    "setuptools (>=70.0.0,<81.0.0)",
     "requests (>=2.33.0,<3.0.0)",
     "urllib3 (>=2.6.3,<3.0.0)"
 ]

--- a/tweet_todays_events.py
+++ b/tweet_todays_events.py
@@ -4,6 +4,7 @@ import os
 import sys
 from playwright.sync_api import sync_playwright
 from requests_oauthlib import OAuth1
+import pkg_resources_compat  # noqa: F401  # twitter_text より前に import すること
 from twitter_text import parse_tweet
 from nijical import NijiCal
 from settings import debug, url_prefix


### PR DESCRIPTION
## 概要

[Dependabot alert #12](https://github.com/magicien/Nij.iCal/security/dependabot/12) (CVE-2026-59890 / GHSA-h35f-9h28-mq5c, setuptools < 83.0.0) の対応です。

GitHub 上から修正を適用しようとするとエラーになるため、手動で対応しました。

## 原因

`pyproject.toml` が `setuptools (>=70.0.0,<81.0.0)` で固定しており、修正版の 83.0.0 がこの範囲外にあるため、Dependabot が有効な更新を作成できませんでした。

単純に上限を上げるだけでは動作しません:

- setuptools は **82.0.0 で `pkg_resources` を完全に削除**（81.0.0 までは非推奨警告付きで同梱）
- `twitter-text-parser 3.0.0` の `twitter_text/regexp/emoji.py` が `import pkg_resources` している
- `tweet_todays_events.py` の `from twitter_text import parse_tweet` がこれを踏み、`ModuleNotFoundError: No module named 'pkg_resources'` で起動時に落ちる

twitter-text-parser は 3.0.0 が最新で修正版が無く、PyPI 上に単体の `pkg_resources` パッケージも存在しません。

## 対応

`pkg_resources.resource_string()` を後継の `importlib.resources` に委譲する互換シム (`pkg_resources_compat.py`) を追加し、**setuptools 依存自体を削除**しました。

依存パッケージ一式を調査したところ、`pkg_resources` を import しているのは `twitter_text` のみでした。そのため setuptools は不要になり、`poetry.lock` からも消えるため alert #12 は解消されます。

- `pkg_resources_compat.py` (新規) — 互換シム。`resource_string` のみ実装
- `tweet_todays_events.py` — `twitter_text` より前にシムを import
- `pyproject.toml` / `poetry.lock` — setuptools 依存を削除

## 動作確認

Python 3.12.13 / setuptools 未インストールの環境で確認:

- `tweet_todays_events.py` およびその他エントリポイント (`tweet_calendar_update.py`, `run.py`, `nijical`) の import が成功
- `parse_tweet('hello 🎉 https://example.com')` → `valid=True, weightedLength=32`（絵文字 2 + URL 23 の重み計算が正しい）
- `parse_tweet('あ' * 200)` → `valid=False, weightedLength=400`（CJK の 2 倍重みが正しい）
- `split_text_for_tweets()` が分割したツイートが全て `valid=True`

`poetry.lock` の差分は setuptools の削除のみで、他パッケージのバージョン変動はありません。

## 備考

このシムは上流が対応するまでの回避策です。twitter-text-parser が更新されるか別ライブラリへ移行した時点で削除できます（その旨は docstring に記載）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)